### PR TITLE
Support any rippled version

### DIFF
--- a/xrpld_netgen/cli.py
+++ b/xrpld_netgen/cli.py
@@ -518,6 +518,7 @@ def main():
         if PROTOCOL == "xrpl":
             BUILD_SERVER: str = "rippleci"
             BUILD_TYPE: str = "image"
+            NETWORK_ID: int = 1
 
         if PROTOCOL == "xrpl" and not BUILD_VERSION:
             BUILD_VERSION: str = XRPL_RELEASE

--- a/xrpld_netgen/libs/github.py
+++ b/xrpld_netgen/libs/github.py
@@ -35,20 +35,20 @@ def get_commit_hash_from_server_version(server: str, version: str) -> str:
         response.raise_for_status()
 
 
-def download_file_at_commit(
-    owner: str, repo: str, commit_hash: str, file_path: str
+def download_file_at_commit_or_tag(
+    owner: str, repo: str, commit_hash_or_tag: str, file_path: str
 ) -> str:
     """
-    Download a specific file from a GitHub repository at a given commit hash.
+    Download a specific file from a GitHub repository at a given commit hash or tag.
 
     :param owner: The owner of the repository (username or organization)
     :param repo: The name of the repository
-    :param commit_hash: The commit hash
+    :param commit_hash_or_tag: The commit hash or version tag
     :param file_path: The path to the file in the repository
     :return: The content of the file
     """
     # Construct the raw content URL
-    url = f"https://raw.githubusercontent.com/{owner}/{repo}/{commit_hash}/{file_path}"
+    url = f"https://raw.githubusercontent.com/{owner}/{repo}/{commit_hash_or_tag}/{file_path}"
 
     # Send a GET request to the URL
     response = requests.get(url)

--- a/xrpld_netgen/main.py
+++ b/xrpld_netgen/main.py
@@ -11,7 +11,7 @@ from xrpld_netgen.rippled_cfg import gen_config, RippledBuild
 from xrpld_netgen.utils.deploy_kit import create_dockerfile, download_binary
 from xrpld_netgen.libs.github import (
     get_commit_hash_from_server_version,
-    download_file_at_commit,
+    download_file_at_commit_or_tag,
 )
 from xrpld_netgen.utils.misc import generate_ports, save_local_config, bcolors
 from xrpl_helpers.common.utils import write_file, read_json
@@ -184,9 +184,6 @@ def create_standalone_folder(
     }
 
 
-ripple_commits = {"2.0.0-b4": "2a66bb3fc725435db5d3551e390001e9352b63a9"}
-
-
 def create_standalone_image(
     log_level: str,
     public_key: str,
@@ -202,8 +199,8 @@ def create_standalone_image(
     os.makedirs(f"{basedir}/{protocol}-{name}", exist_ok=True)
     owner = "XRPLF"
     repo = "rippled"
-    content: str = download_file_at_commit(
-        owner, repo, ripple_commits[build_name], "src/ripple/protocol/impl/Feature.cpp"
+    content: str = download_file_at_commit_or_tag(
+        owner, repo, build_name, "src/ripple/protocol/impl/Feature.cpp"
     )
     image: str = f"{build_system}/rippled:{build_name}"
     create_standalone_folder(
@@ -393,7 +390,7 @@ def create_standalone_binary(
     owner = "Xahau"
     repo = "xahaud"
     commit_hash = get_commit_hash_from_server_version(build_server, build_version)
-    content: str = download_file_at_commit(
+    content: str = download_file_at_commit_or_tag(
         owner, repo, commit_hash, "src/ripple/protocol/impl/Feature.cpp"
     )
     url: str = f"{build_server}/{build_version}"

--- a/xrpld_netgen/network.py
+++ b/xrpld_netgen/network.py
@@ -18,7 +18,7 @@ from xrpld_netgen.utils.deploy_kit import (
 )
 from xrpld_netgen.libs.github import (
     get_commit_hash_from_server_version,
-    download_file_at_commit,
+    download_file_at_commit_or_tag,
 )
 from xrpld_netgen.utils.misc import (
     download_json,
@@ -411,7 +411,7 @@ def create_network(
         owner = "Xahau"
         repo = "xahaud"
         commit_hash = get_commit_hash_from_server_version(build_server, build_version)
-        content: str = download_file_at_commit(
+        content: str = download_file_at_commit_or_tag(
             owner, repo, commit_hash, "src/ripple/protocol/impl/Feature.cpp"
         )
         url: str = f"{build_server}/{build_version}"
@@ -419,13 +419,12 @@ def create_network(
         image: str = "ubuntu:jammy"
 
     if protocol == "xrpl":
-        name: str = build_version.replace(":", "-")
+        name: str = build_version
         os.makedirs(f"{basedir}/{name}-cluster", exist_ok=True)
-        image_name, version = parse_image_name(build_version)
-        root_url = "https://storage.googleapis.com/thelab-builds/"
-        content: str = (
-            root_url
-            + f"{image_name.split('-')[0]}/{image_name.split('-')[1]}/{version}/features.json"  # noqa: E501
+        owner = "XRPLF"
+        repo = "rippled"
+        content: str = download_file_at_commit_or_tag(
+            owner, repo, build_version, "src/ripple/protocol/impl/Feature.cpp"
         )
         image: str = f"{build_server}/{build_version}"
 
@@ -571,7 +570,7 @@ def create_ansible(
         owner = "Xahau"
         repo = "xahaud"
         commit_hash = get_commit_hash_from_server_version(build_server, build_version)
-        content: str = download_file_at_commit(
+        content: str = download_file_at_commit_or_tag(
             owner, repo, commit_hash, "src/ripple/protocol/impl/Feature.cpp"
         )
         url: str = f"{build_server}/{build_version}"


### PR DESCRIPTION
## High Level Overview of Change

Allows any version of rippled

### Context of Change

Fix `download_file_at_commit` to use version tag same as commit hash in github content URL, because version tag can be used as it is in the commit hash part.

`https://raw.githubusercontent.com/XRPLF/rippled/40b4adc9cc296a7e3c6e8c94b5a977a54c835613/src/ripple/protocol/impl/BuildInfo.cpp`

`https://raw.githubusercontent.com/XRPLF/rippled/2.2.0-rc3/src/ripple/protocol/impl/Feature.cpp`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x ] Refactor (non-breaking change that only restructures code)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->